### PR TITLE
Add support for AMD CPUs temperature reading

### DIFF
--- a/internal/data/depent.go
+++ b/internal/data/depent.go
@@ -288,7 +288,7 @@ func getCpuTemp(ch chan int, errch chan error) {
 			errch <- err
 			ch <- 0
 		}
-		if string(f) == "coretemp\n" {
+		if string(f) == "coretemp\n" || string(f) == "k10temp\n" {
 			isCoreTemp = true
 			coreTempDir = hwmn
 		}


### PR DESCRIPTION
AMD CPUs use a different kernel driver, so the content in the "name" file does not say `coretemp`, instead it says `k10temp`. This resulted in AMD processors showing 0 instead of the actual temperature. This PR fixes that.

Should fix #2, but after reading it, maybe it is more complicated than just changing a string as the issue mentions 

https://www.kernel.org/doc/html/latest/hwmon/k10temp.html